### PR TITLE
FEATURE: Add CMake based build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,31 @@
+cmake_minimum_required(VERSION 3.16)
+project(deepbacksub CXX)
+
+find_package(OpenCV REQUIRED COMPONENTS core imgproc imgcodecs video videoio highgui)
+
+# This assumes that tensorflow got checked out as submodule.
+# True, if `git clone` had the additional option `--recursive`.
+add_subdirectory(tensorflow/tensorflow/lite 
+  "${CMAKE_CURRENT_BINARY_DIR}/tensorflow-lite" EXCLUDE_FROM_ALL)
+
+add_executable(deepseg
+  deepseg.cc
+  loopback.cc 
+  transpose_conv_bias.cc
+)
+
+target_link_libraries(deepseg 
+      tensorflow-lite ${CMAKE_DL_LIBS}
+      opencv_core 
+      opencv_video
+      opencv_videoio
+      opencv_imgproc
+      opencv_imgcodecs
+      opencv_highgui
+)
+
+
+install(TARGETS deepseg)
+install(DIRECTORY models 
+    DESTINATION ${CMAKE_INSTALL_PREFIX}/share/deepbacksub 
+    FILES_MATCHING PATTERN "*.tflite" PATTERN "*.md")

--- a/README.md
+++ b/README.md
@@ -111,13 +111,18 @@ Tested with the following software:
 
 Install dependencies (`sudo apt install libopencv-dev build-essential v4l2loopback-dkms curl`).
 
+Clone this repository with `git clone --recursive https://github.com/floe/deepbacksub.git`.
+To speed up the checkout you can additionally pass `--depth=1` to `git clone`.
+This is okay, if you only want to download and build the code, however, for development it is not recommended.
+
 Run `make` to build everything (should also clone and build Tensorflow Lite).
+Alternatively, you can also use `cmake`. Create a subfolder (e.g. `build`), change to that folder and run: `cmake && make -j4` (please replace "4" with the number of your cores).
 
 If the first part doesn't work:
   - Clone https://github.com/tensorflow/tensorflow/ repo into `tensorflow/` folder
   - Checkout tag v2.4.0
-  - run ./tensorflow/lite/tools/make/download_dependencies.sh
-  - run ./tensorflow/lite/tools/make/build_lib.sh
+  - run ./tensorflow/lite/tools/make/download_dependencies.sh (only for non-cmake build)
+  - run ./tensorflow/lite/tools/make/build_lib.sh (only for non-cmake build)
 
 ## Usage
 


### PR DESCRIPTION
Thanks for this cool project!

Tensorflow-lite can now be used as a cmake subproject, which makes the build more robust and IMHO simplifies it.

This is a cmake project file using the aforementioned subproject feature. Hope you find it useful!