### PR TITLE
Enable XNNPACK in CMake builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,10 @@ project(deepbacksub CXX)
 
 find_package(OpenCV REQUIRED COMPONENTS core imgproc imgcodecs video videoio highgui)
 
+# force compilation of XNNPACK delegate (without this the too clever-by-half use
+# of weak/strong symbol linking fails in a static library)
+add_compile_definitions(TFLITE_BUILD_WITH_XNNPACK_DELEGATE)
+
 # This assumes that tensorflow got checked out as submodule.
 # True, if `git clone` had the additional option `--recursive`.
 add_subdirectory(tensorflow/tensorflow/lite 


### PR DESCRIPTION
enables use of XNNPACK delegate by default on CPU, which provides ~2x performance improvement.