### PR TITLE
Windows build of libbackscrub

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,8 @@ target_link_libraries(backscrub
   opencv_imgproc
 )
 
+# We don't build the Linux-specific wrapper application on Windows
+if(NOT WIN32)
 add_library(videoio
   videoio/loopback.cc)
 
@@ -83,6 +85,7 @@ target_link_libraries(deepseg
   opencv_imgcodecs
   opencv_highgui
 )
+endif()
 
 # Export our library, and all transitive dependencies - sadly Tensorflow Lite's
 # CMakeLists.txt does not export these for us

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,7 +129,9 @@ export(TARGETS
   FILE BackscrubTargets.cmake)
 
 # installation names for library, header and models
+if(NOT WIN32)
 install(TARGETS deepseg)
+endif()
 install(TARGETS backscrub)
 install(FILES lib/libbackscrub.h DESTINATION include/backscrub)
 install(DIRECTORY models


### PR DESCRIPTION
Omit wrapper application from CMake build (it depends on video4linux)
Revert to older structure initialisation (pre c++17) to support MSVC compiler