### PR TITLE
update Tensorflow to v2.6.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "tensorflow"]
 	path = tensorflow
 	url = https://github.com/tensorflow/tensorflow
-	branch = v2.5.0
+	branch = v2.6.0


### PR DESCRIPTION
As per #120, this PR updates Tensorflow to v2.6.0, which appears to fix a number of build issues (#93, #103, #119) on distros that have more up to date compilers (GCC-11, clang-12).