### PR TITLE
bug fix: avoid OpenCV display calls on multiple threads, merge debug video windows

### DIFF
--- a/app/background.cc
+++ b/app/background.cc
@@ -11,24 +11,24 @@
 
 // Internal state of background processing
 struct background_t {
-    int dbg;
-    bool vid;
+    int debug;
+    bool video;
     volatile bool run;
     cv::VideoCapture cap;
-    int frm;
+    int frame;
     double fps;
     cv::Mat raw;
-    cv::Mat thm;
-    std::thread thr;
-    std::mutex mux;
-    std::mutex mtm;
+    cv::Mat thumb;
+    std::thread thread;
+    std::mutex rawmux;
+    std::mutex thumbmux;
 };
 
 // Internal video reader thread
 static void read_thread(std::shared_ptr<background_t> pbkd) {
-    if (pbkd->dbg) fprintf(stderr, "background: thread start\n");
+    if (pbkd->debug) fprintf(stderr, "background: thread start\n");
     auto last = std::chrono::steady_clock::now();
-    auto proc = last;
+    auto next = last;
     while (pbkd->run) {
         // read new frame - we use a temporary buffer for two reasons:
         // - we can read unlocked, thus we are not impacted by blocking backends (eg: V4L2)
@@ -37,62 +37,62 @@ static void read_thread(std::shared_ptr<background_t> pbkd) {
         if (pbkd->cap.read(grab)) {
             // got a frame, lock and copy for callers
             {
-                std::unique_lock<std::mutex> hold(pbkd->mux);
+                std::unique_lock<std::mutex> hold(pbkd->rawmux);
                 grab.copyTo(pbkd->raw);
-                pbkd->frm += 1;
+                pbkd->frame += 1;
             }
             // grab timing point
             auto now = std::chrono::steady_clock::now();
             // generate thumbnail frame with overlay info if double debug enabled
-            if (pbkd->dbg > 1) {
+            if (pbkd->debug > 1) {
                 char msg[40];
                 long nsec = std::chrono::duration_cast<std::chrono::nanoseconds>(now-last).count();
                 double fps = 1e9/(double)nsec;
                 {
-                    std::unique_lock<std::mutex> hold(pbkd->mtm);
-                    cv::resize(grab, pbkd->thm, cv::Size(160,120));
+                    std::unique_lock<std::mutex> hold(pbkd->thumbmux);
+                    cv::resize(grab, pbkd->thumb, cv::Size(160,120));
                     snprintf(msg, sizeof(msg), "FPS:%0.1f", fps);
-                    cv::putText(pbkd->thm, msg, cv::Point(5,15), cv::FONT_HERSHEY_PLAIN, 1.0, cv::Scalar(0,255,0));
-                    snprintf(msg, sizeof(msg), "FRM:%05d", fps, pbkd->frm);
-                    cv::putText(pbkd->thm, msg, cv::Point(5,30), cv::FONT_HERSHEY_PLAIN, 1.0, cv::Scalar(0,255,0));
-                    cv::putText(pbkd->thm, "Background", cv::Point(5,pbkd->thm.rows-5), cv::FONT_HERSHEY_PLAIN, 1.0, cv::Scalar(0,255,0));
+                    cv::putText(pbkd->thumb, msg, cv::Point(5,15), cv::FONT_HERSHEY_PLAIN, 1.0, cv::Scalar(0,255,0));
+                    snprintf(msg, sizeof(msg), "FRM:%05d", fps, pbkd->frame);
+                    cv::putText(pbkd->thumb, msg, cv::Point(5,30), cv::FONT_HERSHEY_PLAIN, 1.0, cv::Scalar(0,255,0));
+                    cv::putText(pbkd->thumb, "Background", cv::Point(5,pbkd->thumb.rows-5), cv::FONT_HERSHEY_PLAIN, 1.0, cv::Scalar(0,255,0));
                 }
             }
             last = now;
             // wait for next frame, some sources are real-time, others are not, this ensures all play in real-time.
-            proc += std::chrono::nanoseconds((long)(1e9/pbkd->fps));
-            while (now < proc) {
-                std::this_thread::sleep_until(proc);
+            next += std::chrono::nanoseconds((long)(1e9/pbkd->fps));
+            while (now < next) {
+                std::this_thread::sleep_until(next);
                 now = std::chrono::steady_clock::now();
             }
         } else {
             // no more frames, but if we processed some, try to reset position and go again
-            if (pbkd->frm>0 && pbkd->cap.set(cv::CAP_PROP_POS_FRAMES, 0)) {
-                std::unique_lock<std::mutex> hold(pbkd->mux);
-                pbkd->frm = 0;
+            if (pbkd->frame>0 && pbkd->cap.set(cv::CAP_PROP_POS_FRAMES, 0)) {
+                std::unique_lock<std::mutex> hold(pbkd->rawmux);
+                pbkd->frame = 0;
             } else {
                 // unable to reset or previous attempt produced no more frames - stop
-                if (pbkd->dbg) fprintf(stderr, "background: thread stopping at end of stream and not resettable\n");
+                if (pbkd->debug) fprintf(stderr, "background: thread stopping at end of stream and not resettable\n");
                 break;
             }
         }
     }
-    if (pbkd->dbg) fprintf(stderr, "background: thread stop\n");
+    if (pbkd->debug) fprintf(stderr, "background: thread stop\n");
 }
 
 static void drop_background(background_t *pbkd) {
     if (!pbkd)
         return;
-    if (pbkd->vid) {
+    if (pbkd->video) {
         // stop capture
         if (pbkd->run) {
             pbkd->run = false;
-            pbkd->thr.join();
+            pbkd->thread.join();
         }
         // clean up
         pbkd->cap.release();
         pbkd->raw.release();
-        pbkd->thm.release();
+        pbkd->thumb.release();
     } else {
         // clean up
         pbkd->raw.release();
@@ -104,12 +104,12 @@ std::shared_ptr<background_t> load_background(const std::string& path, int debug
     // allocate a shared pointer around storage for the handle, associate custom deleter to clean up when eventually released
     auto pbkd = std::shared_ptr<background_t>(new background_t, drop_background);
     try {
-        pbkd->dbg = debug;
-        pbkd->vid = false;
+        pbkd->debug = debug;
+        pbkd->video = false;
         pbkd->run = false;
         pbkd->cap.open(path, cv::CAP_ANY);    // explicitly ask for auto-detection of backend
         if (!pbkd->cap.isOpened()) {
-            if (pbkd->dbg) fprintf(stderr, "background: cap cannot open: %s\n", path.c_str());
+            if (pbkd->debug) fprintf(stderr, "background: cap cannot open: %s\n", path.c_str());
             return nullptr;
         }
         pbkd->cap.set(cv::CAP_PROP_CONVERT_RGB, true);
@@ -123,30 +123,30 @@ std::shared_ptr<background_t> load_background(const std::string& path, int debug
         if (pbkd->cap.read(pbkd->raw) && pbkd->cap.read(pbkd->raw)) {
             // it's a video, try a reset and start reader thread..
             if (pbkd->cap.set(cv::CAP_PROP_POS_FRAMES, 0))
-                pbkd->frm = 0;
+                pbkd->frame = 0;
             else
-                pbkd->frm = 2;    // unable to reset, so we're 2 frames in
-            pbkd->vid = true;
+                pbkd->frame = 2;    // unable to reset, so we're 2 frames in
+            pbkd->video = true;
             pbkd->run = true;
-            pbkd->thr = std::thread(read_thread, pbkd);
+            pbkd->thread = std::thread(read_thread, pbkd);
         } else {
             // static image file, try loading..
             pbkd->cap.release();
             pbkd->raw = cv::imread(path);
             if (pbkd->raw.empty()) {
-                if (pbkd->dbg) fprintf(stderr, "background: imread cannot open: %s\n", path.c_str());
+                if (pbkd->debug) fprintf(stderr, "background: imread cannot open: %s\n", path.c_str());
                 return nullptr;
             }
         }
-        if (pbkd->dbg)
+        if (pbkd->debug)
             fprintf(stderr, "background properties:\n\tvid: %s\n\tfcc: %08x (%.4s)\n\tfps: %f\n\tcnt: %d\n",
-                pbkd->vid ? "yes":"no", fcc, (char *)&fcc, pbkd->fps, cnt);
+                pbkd->video ? "yes":"no", fcc, (char *)&fcc, pbkd->fps, cnt);
     } catch (std::exception const &e) {
         // oops
-        if (pbkd->dbg) fprintf(stderr, "background: exception while loading: %s\n", e.what());
+        if (pbkd->debug) fprintf(stderr, "background: exception while loading: %s\n", e.what());
         return nullptr;
     } catch (...) {
-        if (pbkd->dbg) fprintf(stderr, "background: unknown exception\n");
+        if (pbkd->debug) fprintf(stderr, "background: unknown exception\n");
         return nullptr;
     }
     return pbkd;
@@ -157,11 +157,11 @@ int grab_background(std::shared_ptr<background_t> pbkd, int width, int height, c
         return -1;
     // static image or video?
     int frm ;
-    if (pbkd->vid) {
+    if (pbkd->video) {
         // grab frame & frame no. under mutex
-        std::unique_lock<std::mutex> hold(pbkd->mux);
+        std::unique_lock<std::mutex> hold(pbkd->rawmux);
         cv::resize(pbkd->raw, out, cv::Size(width, height));
-        frm = pbkd->frm;
+        frm = pbkd->frame;
     } else {
         // resize still image as requested into out
         cv::resize(pbkd->raw, out, cv::Size(width, height));
@@ -173,7 +173,7 @@ int grab_background(std::shared_ptr<background_t> pbkd, int width, int height, c
 int grab_thumbnail(std::shared_ptr<background_t> pbkd, cv::Mat &out) {
     if (!pbkd)
         return -1;
-    std::unique_lock<std::mutex> hold(pbkd->mtm);
-    out = pbkd->thm.clone();
+    std::unique_lock<std::mutex> hold(pbkd->thumbmux);
+    out = pbkd->thumb.clone();
     return 0;
 }

--- a/app/background.cc
+++ b/app/background.cc
@@ -52,10 +52,10 @@ static void read_thread(std::shared_ptr<background_t> pbkd) {
                     std::unique_lock<std::mutex> hold(pbkd->thumbmux);
                     cv::resize(grab, pbkd->thumb, cv::Size(160,120));
                     snprintf(msg, sizeof(msg), "FPS:%0.1f", fps);
-                    cv::putText(pbkd->thumb, msg, cv::Point(5,15), cv::FONT_HERSHEY_PLAIN, 1.0, cv::Scalar(0,255,0));
+                    cv::putText(pbkd->thumb, msg, cv::Point(5,15), cv::FONT_HERSHEY_PLAIN, 1.0, cv::Scalar(0,255,255));
                     snprintf(msg, sizeof(msg), "FRM:%05d", fps, pbkd->frame);
-                    cv::putText(pbkd->thumb, msg, cv::Point(5,30), cv::FONT_HERSHEY_PLAIN, 1.0, cv::Scalar(0,255,0));
-                    cv::putText(pbkd->thumb, "Background", cv::Point(5,pbkd->thumb.rows-5), cv::FONT_HERSHEY_PLAIN, 1.0, cv::Scalar(0,255,0));
+                    cv::putText(pbkd->thumb, msg, cv::Point(5,30), cv::FONT_HERSHEY_PLAIN, 1.0, cv::Scalar(0,255,255));
+                    cv::putText(pbkd->thumb, "Background", cv::Point(5,pbkd->thumb.rows-5), cv::FONT_HERSHEY_PLAIN, 1.0, cv::Scalar(0,255,255));
                 }
             }
             last = now;

--- a/app/background.cc
+++ b/app/background.cc
@@ -25,7 +25,7 @@ struct background_t {
 };
 
 // Internal video reader thread
-static void read_thread(std::shared_ptr<background_t> pbkd) {
+static void read_thread(background_t *pbkd) {
     if (pbkd->debug) fprintf(stderr, "background: thread start\n");
     auto last = std::chrono::steady_clock::now();
     auto next = last;
@@ -131,7 +131,7 @@ std::shared_ptr<background_t> load_background(const std::string& path, int debug
                 pbkd->frame = 2;    // unable to reset, so we're 2 frames in
             pbkd->video = true;
             pbkd->run = true;
-            pbkd->thread = std::thread(read_thread, pbkd);
+            pbkd->thread = std::thread(read_thread, pbkd.get());
         } else {
             // static image file, try loading..
             pbkd->cap.release();

--- a/app/background.cc
+++ b/app/background.cc
@@ -174,6 +174,6 @@ int grab_thumbnail(std::shared_ptr<background_t> pbkd, cv::Mat &out) {
     if (!pbkd)
         return -1;
     std::unique_lock<std::mutex> hold(pbkd->mtm);
-    pbkd->thm.copyTo(out);
+    out = pbkd->thm.clone();
     return 0;
 }

--- a/app/background.h
+++ b/app/background.h
@@ -18,4 +18,8 @@ std::shared_ptr<background_t> load_background(const std::string& path, int debug
 // NB: current frame can loop round to 0!
 int grab_background(std::shared_ptr<background_t> handle, int width, int height, cv::Mat &out);
 
+// Grab current thumbnail image (if any) from background
+// Returns <0 on error, 0 on success and copies thumbnail to out
+int grab_thumbnail(std::shared_ptr<background_t> handle, cv::Mat &out);
+
 #endif

--- a/app/deepseg.cc
+++ b/app/deepseg.cc
@@ -331,6 +331,8 @@ int main(int argc, char* argv[]) try {
 	ti.bootns = timestamp();
 	int debug  = 0;
 	bool showProgress = false;
+	bool showBackground = true;
+	bool showFPS = true;
 	size_t threads= 2;
 	size_t width  = 640;
 	size_t height = 480;
@@ -630,9 +632,22 @@ int main(int argc, char* argv[]) try {
 
 		cv::Mat test;
 		cv::cvtColor(raw,test,cv::COLOR_YUV2BGR_YUYV);
-		char status[80];
-		snprintf(status, sizeof(status), "MainFPS: %5.2f AiFPS: %5.2f", mfps, afps);
-		cv::putText(test, status, cv::Point(5,test.rows-5), cv::FONT_HERSHEY_PLAIN, 1.0, cv::Scalar(0,255,0));
+		if (showFPS) {
+			char status[80];
+			snprintf(status, sizeof(status), "MainFPS: %5.2f AiFPS: %5.2f", mfps, afps);
+			cv::putText(test, status, cv::Point(5,test.rows-5), cv::FONT_HERSHEY_PLAIN, 1.0, cv::Scalar(0,255,0));
+		}
+		// background as pic-in-pic
+		if (showBackground && pbk) {
+			cv::Mat thumb;
+			grab_thumbnail(pbk, thumb);
+			if (!thumb.empty()) {
+				cv::Rect r = cv::Rect(0,0,thumb.cols,thumb.rows);
+				cv::Mat tri = test(r);
+				thumb.copyTo(tri);
+				cv::rectangle(tri, r, cv::Scalar(255,255,255));
+			}
+		}
 		cv::imshow(DEBUG_WIN_NAME,test);
 
 		auto keyPress = cv::waitKey(1);
@@ -648,6 +663,12 @@ int main(int argc, char* argv[]) try {
 				break;
 			case 'v':
 				flipVertical = !flipVertical;
+				break;
+			case 'f':
+				showFPS = !showFPS;
+				break;
+			case 'b':
+				showBackground = !showBackground;
 				break;
 		}
 	}

--- a/app/deepseg.cc
+++ b/app/deepseg.cc
@@ -642,18 +642,18 @@ int main(int argc, char* argv[]) try {
 		}
 		// keyboard help
 		if (showHelp) {
-			static const char *help[] = {
+			static const std::string help[] = {
 				"Keyboard help:",
-				" q: Quit",
-				" s: Switch filter on/off",
-				" h: toggle Horizontal flip",
-				" v: toggle Vertical flip",
+				" q: quit",
+				" s: switch filter on/off",
+				" h: toggle horizontal flip",
+				" v: toggle vertical flip",
 				" f: toggle FPS display on/off",
-				" b: toggle Background display on/off",
-				" m: toggle Mask display on/off",
+				" b: toggle background display on/off",
+				" m: toggle mask display on/off",
 				" ?: toggle this help text on/off"
 			};
-			for (int i=0; i<sizeof(help)/sizeof(char*); i++) {
+			for (int i=0; i<sizeof(help)/sizeof(std::string); i++) {
 				cv::putText(test, help[i], cv::Point(10,test.rows/2+i*15), cv::FONT_HERSHEY_PLAIN, 1.0, cv::Scalar(0,255,255));
 			}
 		}

--- a/app/deepseg.cc
+++ b/app/deepseg.cc
@@ -638,7 +638,7 @@ int main(int argc, char* argv[]) try {
 		if (showFPS) {
 			char status[80];
 			snprintf(status, sizeof(status), "MainFPS: %5.2f AiFPS: %5.2f", mfps, afps);
-			cv::putText(test, status, cv::Point(5,test.rows-5), cv::FONT_HERSHEY_PLAIN, 1.0, cv::Scalar(0,255,0));
+			cv::putText(test, status, cv::Point(5,test.rows-5), cv::FONT_HERSHEY_PLAIN, 1.0, cv::Scalar(0,255,255));
 		}
 		// keyboard help
 		if (showHelp) {
@@ -654,7 +654,7 @@ int main(int argc, char* argv[]) try {
 				" ?: toggle this help text on/off"
 			};
 			for (int i=0; i<sizeof(help)/sizeof(char*); i++) {
-				cv::putText(test, help[i], cv::Point(10,test.rows/2+i*15), cv::FONT_HERSHEY_PLAIN, 1.0, cv::Scalar(0,255,0));
+				cv::putText(test, help[i], cv::Point(10,test.rows/2+i*15), cv::FONT_HERSHEY_PLAIN, 1.0, cv::Scalar(0,255,255));
 			}
 		}
 		// background as pic-in-pic
@@ -678,7 +678,7 @@ int main(int argc, char* argv[]) try {
 				cv::Mat mri = test(r);
 				cmask.copyTo(mri);
 				cv::rectangle(test, r, cv::Scalar(255,255,255));
-				cv::putText(test, "Mask", cv::Point(width-155,115), cv::FONT_HERSHEY_PLAIN, 1.0, cv::Scalar(0,255,0));
+				cv::putText(test, "Mask", cv::Point(width-155,115), cv::FONT_HERSHEY_PLAIN, 1.0, cv::Scalar(0,255,255));
 			}
 		}
 		cv::imshow(DEBUG_WIN_NAME,test);

--- a/app/deepseg.cc
+++ b/app/deepseg.cc
@@ -33,7 +33,7 @@
 #error No INSTALL_PREFIX defined at compile time
 #endif
 
-#define DEBUG_WIN_NAME "Backscrub " _STR(DEEPSEG_VERSION)
+#define DEBUG_WIN_NAME "Backscrub " _STR(DEEPSEG_VERSION) " ('?' for help)"
 
 int fourCcFromString(const std::string& in)
 {
@@ -332,7 +332,9 @@ int main(int argc, char* argv[]) try {
 	int debug  = 0;
 	bool showProgress = false;
 	bool showBackground = true;
+	bool showMask = true;
 	bool showFPS = true;
+	bool showHelp = false;
 	size_t threads= 2;
 	size_t width  = 640;
 	size_t height = 480;
@@ -632,10 +634,28 @@ int main(int argc, char* argv[]) try {
 
 		cv::Mat test;
 		cv::cvtColor(raw,test,cv::COLOR_YUV2BGR_YUYV);
+		// frame rates at the bottom
 		if (showFPS) {
 			char status[80];
 			snprintf(status, sizeof(status), "MainFPS: %5.2f AiFPS: %5.2f", mfps, afps);
 			cv::putText(test, status, cv::Point(5,test.rows-5), cv::FONT_HERSHEY_PLAIN, 1.0, cv::Scalar(0,255,0));
+		}
+		// keyboard help
+		if (showHelp) {
+			static const char *help[] = {
+				"Keyboard help:",
+				" q: Quit",
+				" s: Switch filter on/off",
+				" h: toggle Horizontal flip",
+				" v: toggle Vertical flip",
+				" f: toggle FPS display on/off",
+				" b: toggle Background display on/off",
+				" m: toggle Mask display on/off",
+				" ?: toggle this help text on/off"
+			};
+			for (int i=0; i<sizeof(help)/sizeof(char*); i++) {
+				cv::putText(test, help[i], cv::Point(10,test.rows/2+i*15), cv::FONT_HERSHEY_PLAIN, 1.0, cv::Scalar(0,255,0));
+			}
 		}
 		// background as pic-in-pic
 		if (showBackground && pbk) {
@@ -645,7 +665,20 @@ int main(int argc, char* argv[]) try {
 				cv::Rect r = cv::Rect(0,0,thumb.cols,thumb.rows);
 				cv::Mat tri = test(r);
 				thumb.copyTo(tri);
-				cv::rectangle(tri, r, cv::Scalar(255,255,255));
+				cv::rectangle(test, r, cv::Scalar(255,255,255));
+			}
+		}
+		// mask as pic-in-pic
+		if (showMask) {
+			if (!mask.empty()) {
+				cv::Mat smask, cmask;
+				cv::resize(mask, smask, cv::Size(160,120));
+				cv::cvtColor(smask, cmask, cv::COLOR_GRAY2BGR);
+				cv::Rect r = cv::Rect(width-160,0,160,120);
+				cv::Mat mri = test(r);
+				cmask.copyTo(mri);
+				cv::rectangle(test, r, cv::Scalar(255,255,255));
+				cv::putText(test, "Mask", cv::Point(width-155,115), cv::FONT_HERSHEY_PLAIN, 1.0, cv::Scalar(0,255,0));
 			}
 		}
 		cv::imshow(DEBUG_WIN_NAME,test);
@@ -669,6 +702,12 @@ int main(int argc, char* argv[]) try {
 				break;
 			case 'b':
 				showBackground = !showBackground;
+				break;
+			case 'm':
+				showMask = !showMask;
+				break;
+			case '?':
+				showHelp = !showHelp;
 				break;
 		}
 	}


### PR DESCRIPTION
These changes ensure OpenCV debug display calls (`cv::imshow()`) are on the main thread only, in an attempt to fix crashes experienced by others when using animated backgrounds. We also merge the separate background debug window into the main debug window (as picture-in-picture) and add keyboard controls to turn this on/off, along with FPS display, so users can grab the debug window as a clean image if required.