### PR TITLE
Add Microsoft Teams version 1.4.00.26453 to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Tested with the following software:
   - Microsoft Teams
     - 1.3.00.30857 (works)
     - 1.3.00.5153 (works)
+    - 1.4.00.26453 (works)
   - Chrome
     - 87.0.4280.88 (works)
     - 81.0.4044.138 (works)


### PR DESCRIPTION
Thank you for your work here. This is awesome.

I have no idea if you care about to receive this kind of information but backscrub works on MS Teams 1.4.00.26453.