### PR TITLE
Performance enhancements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,8 +58,8 @@ add_subdirectory(${TENSORFLOW}/tensorflow/lite
 
 # build backscrub code
 add_compile_definitions(DEEPSEG_VERSION=${DEEPSEG_VERSION} INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX})
+add_compile_options(-march=native -O9)
 include_directories(BEFORE .)
-set(CMAKE_CXX_STANDARD 17)
 
 add_library(backscrub
   lib/libbackscrub.cc
@@ -87,8 +87,6 @@ add_executable(deepseg
   app/calcmask.cc
   app/utils.cc
 )
-# special compile options for blend.cc to use SIMD optimiser
-set_source_files_properties(app/blend.cc PROPERTIES COMPILE_OPTIONS "-march=native;-O9")
 
 set_target_properties(deepseg PROPERTIES OUTPUT_NAME backscrub)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,9 +83,12 @@ target_link_libraries(videoio)
 add_executable(deepseg
   app/deepseg.cc
   app/background.cc
+  app/blend.cc
   app/calcmask.cc
   app/utils.cc
 )
+# special compile options for blend.cc to use SIMD optimiser
+set_source_files_properties(app/blend.cc PROPERTIES COMPILE_OPTIONS "-march=native;-O9")
 
 set_target_properties(deepseg PROPERTIES OUTPUT_NAME backscrub)
 

--- a/app/blend.cc
+++ b/app/blend.cc
@@ -1,0 +1,35 @@
+#include "utils.h"
+
+cv::Mat alpha_blend(const cv::Mat& srca, const cv::Mat& srcb, const cv::Mat& mask) {
+	// alpha blend two (8UC3) source images using a mask (8UC1, 255=>srca, 0=>srcb), adapted from:
+	// https://www.learnopencv.com/alpha-blending-using-opencv-cpp-python/
+	// "trust no-one" => we're about to mess with data pointers
+	assert(srca.rows == srcb.rows);
+	assert(srca.cols == srcb.cols);
+	assert(mask.rows == srca.rows);
+	assert(mask.cols == srca.cols);
+
+	assert(srca.type() == CV_8UC3);
+	assert(srcb.type() == CV_8UC3);
+	assert(mask.type() == CV_8UC1);
+
+	const uint8_t *aptr = (const uint8_t*)srca.data;
+	const uint8_t *bptr = (const uint8_t*)srcb.data;
+	const uint8_t *mptr = (const uint8_t*)mask.data;
+
+	cv::Mat out;
+	out.create(srca.size(), srca.type());
+	uint8_t *optr = (uint8_t*)out.data;
+
+	for (size_t pix = 0, npix = srca.rows * srca.cols; pix < npix; ++pix) {
+		// blending weights
+		int aw = (int)(*mptr++);
+		int bw = 255 - aw;
+
+		// blend each channel byte
+		*optr++ = (uint8_t)(( (int)(*aptr++) * aw + (int)(*bptr++) * bw ) >> 8);
+		*optr++ = (uint8_t)(( (int)(*aptr++) * aw + (int)(*bptr++) * bw ) >> 8);
+		*optr++ = (uint8_t)(( (int)(*aptr++) * aw + (int)(*bptr++) * bw ) >> 8);
+	}
+	return out;
+}

--- a/app/blend.cc
+++ b/app/blend.cc
@@ -21,15 +21,16 @@ cv::Mat alpha_blend(const cv::Mat& srca, const cv::Mat& srcb, const cv::Mat& mas
 	out.create(srca.size(), srca.type());
 	uint8_t *optr = (uint8_t*)out.data;
 
-	for (size_t pix = 0, npix = srca.rows * srca.cols; pix < npix; ++pix) {
-		// blending weights
-		int aw = (int)(*mptr++);
-		int bw = 255 - aw;
-
+	// by removing this to a constant, and using const weights, GCC can vectorize this loop
+	const size_t npix = srca.rows * srca.cols;
+	for (size_t pix = 0; pix < npix; ++pix) {
+		// calculate pre-multipied weights
+		const uint32_t aw = (uint32_t)(*mptr++)*257;
+		const uint32_t bw = 65535 - aw;
 		// blend each channel byte
-		*optr++ = (uint8_t)(( (int)(*aptr++) * aw + (int)(*bptr++) * bw ) >> 8);
-		*optr++ = (uint8_t)(( (int)(*aptr++) * aw + (int)(*bptr++) * bw ) >> 8);
-		*optr++ = (uint8_t)(( (int)(*aptr++) * aw + (int)(*bptr++) * bw ) >> 8);
+		*optr++ = (uint8_t)(( (uint32_t)(*aptr++) * aw + (uint32_t)(*bptr++) * bw ) >> 16);
+		*optr++ = (uint8_t)(( (uint32_t)(*aptr++) * aw + (uint32_t)(*bptr++) * bw ) >> 16);
+		*optr++ = (uint8_t)(( (uint32_t)(*aptr++) * aw + (uint32_t)(*bptr++) * bw ) >> 16);
 	}
 	return out;
 }

--- a/app/utils.cc
+++ b/app/utils.cc
@@ -38,32 +38,6 @@ int fourCcFromString(const std::string& in) {
 	return 0;
 }
 
-// OpenCV helper functions
-cv::Mat convert_rgb_to_yuyv(const cv::Mat& input) {
-	cv::Mat tmp;
-	cv::cvtColor(input, tmp, cv::COLOR_RGB2YUV);
-	std::vector<cv::Mat> yuv;
-	cv::split(tmp, yuv);
-	cv::Mat yuyv(tmp.rows, tmp.cols, CV_8UC2);
-
-	uint8_t* outdata = (uint8_t*)yuyv.data;
-	uint8_t* ydata = (uint8_t*)yuv[0].data;
-	uint8_t* udata = (uint8_t*)yuv[1].data;
-	uint8_t* vdata = (uint8_t*)yuv[2].data;
-
-	for (unsigned int i = 0; i < yuyv.total(); i += 2) {
-		uint8_t u = (uint8_t)(((int)udata[i] + (int)udata[i + 1]) / 2);
-		uint8_t v = (uint8_t)(((int)vdata[i] + (int)vdata[i + 1]) / 2);
-
-		outdata[2 * i + 0] = ydata[i + 0];
-		outdata[2 * i + 1] = v;
-		outdata[2 * i + 2] = ydata[i + 1];
-		outdata[2 * i + 3] = u;
-	}
-
-	return yuyv;
-}
-
 timestamp_t timestamp() {
 	return std::chrono::high_resolution_clock::now();
 }
@@ -71,7 +45,6 @@ long diffnanosecs(const timestamp_t& t1, const timestamp_t& t2) {
 	return std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t2).count();
 }
 
-// encapsulation of mask calculation logic and threading
 bool is_number(const std::string &s) {
 	return !s.empty() && std::all_of(s.begin(), s.end(), ::isdigit);
 }

--- a/app/utils.cc
+++ b/app/utils.cc
@@ -64,40 +64,6 @@ cv::Mat convert_rgb_to_yuyv(const cv::Mat& input) {
 	return yuyv;
 }
 
-cv::Mat alpha_blend(const cv::Mat& srca, const cv::Mat& srcb, const cv::Mat& mask) {
-	// alpha blend two (8UC3) source images using a mask (8UC1, 255=>srca, 0=>srcb), adapted from:
-	// https://www.learnopencv.com/alpha-blending-using-opencv-cpp-python/
-	// "trust no-one" => we're about to mess with data pointers
-	assert(srca.rows == srcb.rows);
-	assert(srca.cols == srcb.cols);
-	assert(mask.rows == srca.rows);
-	assert(mask.cols == srca.cols);
-
-	assert(srca.type() == CV_8UC3);
-	assert(srcb.type() == CV_8UC3);
-	assert(mask.type() == CV_8UC1);
-
-	const uint8_t *aptr = (const uint8_t*)srca.data;
-	const uint8_t *bptr = (const uint8_t*)srcb.data;
-	const uint8_t *mptr = (const uint8_t*)mask.data;
-
-	cv::Mat out = cv::Mat::zeros(srca.size(), srca.type());
-	uint8_t *optr = (uint8_t*)out.data;
-
-	for (size_t pix = 0, npix = srca.rows * srca.cols; pix < npix; ++pix) {
-		// blending weights
-		int aw = (int)(*mptr++);
-		int bw = 255 - aw;
-
-		// blend each channel byte
-		*optr++ = (uint8_t)(( (int)(*aptr++) * aw + (int)(*bptr++) * bw ) / 255);
-		*optr++ = (uint8_t)(( (int)(*aptr++) * aw + (int)(*bptr++) * bw ) / 255);
-		*optr++ = (uint8_t)(( (int)(*aptr++) * aw + (int)(*bptr++) * bw ) / 255);
-	}
-
-	return out;
-}
-
 timestamp_t timestamp() {
 	return std::chrono::high_resolution_clock::now();
 }


### PR DESCRIPTION
Specifically to `alpha_blend` and `convert_rgb_to_yuyv` as per #138 

This first draft addresses `alpha_blend`, reducing run time by a factor of 3-4x simply by separating the function and turning on full compiler optimisation __for the machine that we are compiling on__ (`-march=native`). This may be a problem if compiling for a different target that doesn't have the same CPU features...