### PR TITLE
update TFLite to v2.8.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "tensorflow"]
 	path = tensorflow
 	url = https://github.com/tensorflow/tensorflow
-	branch = v2.7.0
+	branch = v2.8.0


### PR DESCRIPTION
As identified in #140. We see a fail-to-build in Tensorflow v2.7.0 on Ubuntu 21.10, fixed by updating to v2.8.0.

Please check this builds & runs on your own local environment and confirm or deny if an update to v2.8.0 is ok.
 * @phlash - works for me on Debian stable (bullseye)