### PR TITLE
Display Tensorflow version during build and at runtime

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ if(NOT DEFINED TENSORFLOW)
   set(TF_CHECKOUT true)
 endif()
 
-# find Git and use it to get backscrub version
+# find Git and use it to get backscrub & Tensorflow versions
 find_package(Git)
 if(GIT_FOUND)
   execute_process(
@@ -22,7 +22,7 @@ if(GIT_FOUND)
 else()
   set(DEEPSEG_VERSION v0.2.0-no-git)
 endif()
-message("Version: ${DEEPSEG_VERSION}")
+message("Backscrub version: ${DEEPSEG_VERSION}")
 
 # always build PIC everywhere
 set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)
@@ -41,6 +41,18 @@ if (TF_CHECKOUT)
 else()
   message(STATUS "Using specified Tensorflow: ${TENSORFLOW}")
 endif(TF_CHECKOUT)
+
+if(GIT_FOUND)
+  get_filename_component(TF_ABS ${TENSORFLOW} ABSOLUTE)
+  execute_process(
+    COMMAND ${GIT_EXECUTABLE} describe --all --long --always --dirty
+    WORKING_DIRECTORY ${TF_ABS}
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    OUTPUT_VARIABLE TF_VERSION)
+else()
+  set(TF_VERSION unknown-no-git)
+endif()
+message(STATUS "Tensorflow version: ${TF_VERSION}")
 
 # force compilation of XNNPACK delegate (without this the too clever-by-half use
 # of weak/strong symbol linking fails in a static library)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,7 @@ add_subdirectory(${TENSORFLOW}/tensorflow/lite
   "${CMAKE_CURRENT_BINARY_DIR}/tensorflow-lite" EXCLUDE_FROM_ALL)
 
 # build backscrub code
-add_compile_definitions(DEEPSEG_VERSION=${DEEPSEG_VERSION} INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX})
+add_compile_definitions(DEEPSEG_VERSION=${DEEPSEG_VERSION} TF_VERSION=${TF_VERSION} INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX})
 include_directories(BEFORE .)
 set(CMAKE_CXX_STANDARD 17)
 

--- a/app/deepseg.cc
+++ b/app/deepseg.cc
@@ -324,10 +324,9 @@ std::optional<std::string> resolve_path(const std::string& provided, const std::
 
 int main(int argc, char* argv[]) try {
 
-	printf("%s version %s\n", argv[0], _STR(DEEPSEG_VERSION));
+	printf("%s version %s (Tensorflow build: %s, run-time: %s)\n", argv[0], _STR(DEEPSEG_VERSION), _STR(TF_VERSION), bs_tensorflow_version());
 	printf("(c) 2021 by floe@butterbrot.org & contributors\n");
 	printf("https://github.com/floe/backscrub\n");
-	printf("(running with Tensorflow Lite version: %s)\n", bs_tensorflow_version());
 	timinginfo_t ti;
 	ti.bootns = timestamp();
 	int debug = 0;

--- a/app/deepseg.cc
+++ b/app/deepseg.cc
@@ -327,6 +327,7 @@ int main(int argc, char* argv[]) try {
 	printf("%s version %s\n", argv[0], _STR(DEEPSEG_VERSION));
 	printf("(c) 2021 by floe@butterbrot.org & contributors\n");
 	printf("https://github.com/floe/backscrub\n");
+	printf("(running with Tensorflow Lite version: %s)\n", bs_tensorflow_version());
 	timinginfo_t ti;
 	ti.bootns = timestamp();
 	int debug = 0;

--- a/app/deepseg.cc
+++ b/app/deepseg.cc
@@ -324,7 +324,7 @@ std::optional<std::string> resolve_path(const std::string& provided, const std::
 
 int main(int argc, char* argv[]) try {
 
-	printf("%s version %s (Tensorflow build: %s, run-time: %s)\n", argv[0], _STR(DEEPSEG_VERSION), _STR(TF_VERSION), bs_tensorflow_version());
+	printf("%s version %s (Tensorflow: build %s, run-time %s)\n", argv[0], _STR(DEEPSEG_VERSION), _STR(TF_VERSION), bs_tensorflow_version());
 	printf("(c) 2021 by floe@butterbrot.org & contributors\n");
 	printf("https://github.com/floe/backscrub\n");
 	timinginfo_t ti;

--- a/lib/libbackscrub.cc
+++ b/lib/libbackscrub.cc
@@ -2,6 +2,7 @@
  * Authors - @see AUTHORS file.
 ==============================================================================*/
 
+#include "tensorflow/lite/version.h"
 #include "tensorflow/lite/interpreter.h"
 #include "tensorflow/lite/kernels/register.h"
 #include "tensorflow/lite/model.h"
@@ -144,6 +145,10 @@ static normalization_t get_normalization(modeltype_t type) {
 			break;
 	}
 	return rv;
+}
+
+const char *bs_tensorflow_version(void) {
+	return TFLITE_VERSION_STRING;
 }
 
 // deeplabv3 classes

--- a/lib/libbackscrub.h
+++ b/lib/libbackscrub.h
@@ -9,6 +9,9 @@
 #include <opencv2/core/core.hpp>
 #include <opencv2/imgproc/imgproc.hpp>
 
+// Get Tensorflow version string
+extern const char *bs_tensorflow_version(void);
+
 // Return a new (opaque) mask generation context
 extern void *bs_maskgen_new(
 	// Required parameters


### PR DESCRIPTION
To help with diagnosis of build and runtime issues - this shows the version of Tensorflow being used in a build (after any forced checkout), and the linked runtime version.