### PR TITLE
Enable streaming on device fd

### DIFF
--- a/app/deepseg.cc
+++ b/app/deepseg.cc
@@ -256,7 +256,7 @@ int main(int argc, char* argv[]) try {
 	}
 
 	on_scope_exit lbfd_closer([lbfd]() {
-		close(lbfd);
+		loopback_free(lbfd);
 	});
 
 	cv::VideoCapture cap(ccam.c_str(), cv::CAP_V4L2);

--- a/videoio/loopback.cc
+++ b/videoio/loopback.cc
@@ -37,7 +37,7 @@ int loopback_init(const std::string& device, int w, int h, int debug) {
 
 	int ret_code;
 
-	int fdwr = open(device.c_str(), O_RDWR);
+	int fdwr = open(device.c_str(), O_RDWR|O_CLOEXEC);
 
 	if(fdwr < 0) {
 		fprintf(stderr, "%s:%d(%s): Failed to open video device: %s\n", __FILE__, __LINE__, __func__, strerror(errno));
@@ -53,21 +53,6 @@ int loopback_init(const std::string& device, int w, int h, int debug) {
 	}
 
 	memset(&vid_format, 0, sizeof(vid_format));
-	vid_format.type = V4L2_BUF_TYPE_VIDEO_OUTPUT;
-
-	ret_code = ioctl(fdwr, VIDIOC_G_FMT, &vid_format);
-	if(ret_code < 0) {
-		fprintf(stderr, "%s:%d(%s): Failed to get device video format: %s\n", __FILE__, __LINE__, __func__, strerror(errno));
-		close(fdwr);
-		return -1;
-	}
-
-	if(ret_code < 0) {
-		fprintf(stderr, "%s:%d(%s): Failed to get device video format: %s\n", __FILE__, __LINE__, __func__, strerror(errno));
-		close(fdwr);
-		return -1;
-	}
-
 	vid_format.type = V4L2_BUF_TYPE_VIDEO_OUTPUT;
 	vid_format.fmt.pix.width = w;
 	vid_format.fmt.pix.height = h;
@@ -85,10 +70,38 @@ int loopback_init(const std::string& device, int w, int h, int debug) {
 		return -1;
 	}
 
+	ret_code = ioctl(fdwr, VIDIOC_STREAMON, &vid_format.type);
+
+	if(ret_code < 0) {
+		fprintf(stderr, "%s:%d(%s): Failed to start streaming: %s\n", __FILE__, __LINE__, __func__, strerror(errno));
+		close(fdwr);
+		return -1;
+	}
+
 	if (debug)
 		print_format(&vid_format);
 
 	return fdwr;
+}
+
+int loopback_free(int fdwr) {
+
+	const v4l2_buf_type type = V4L2_BUF_TYPE_VIDEO_OUTPUT;
+
+	int ret_code = ioctl(fdwr, VIDIOC_STREAMOFF, &type);
+
+	if(ret_code < 0) {
+		fprintf(stderr, "%s:%d(%s): Failed to stop streaming: %s\n", __FILE__, __LINE__, __func__, strerror(errno));
+		return -1;
+	}
+
+	ret_code = close(fdwr);
+	if(ret_code < 0) {
+		fprintf(stderr, "%s:%d(%s): Failed to close video device: %s\n", __FILE__, __LINE__, __func__, strerror(errno));
+		return -1;
+	}
+
+	return 0;
 }
 
 #ifdef standalone

--- a/videoio/loopback.h
+++ b/videoio/loopback.h
@@ -7,5 +7,6 @@
 #include <string>
 
 int loopback_init(const std::string& device, int w, int h, int debug);
+int loopback_free(int fdwr);
 
 #endif // _LOOPBACK_H_


### PR DESCRIPTION
This ensures the opener of the fd in the kernel module is updated to be a WRITER.
Failing to do so causes the video output capability to be lost when closing the fd.

Cf. https://github.com/floe/backscrub/issues/133
Cf. https://github.com/umlaeute/v4l2loopback/issues/470

Also this commit introduces a proper `loopback_free` function to release any resources and provide a central point for cleanup before closing the fd.

Fixes #133